### PR TITLE
Support vendor pseudo elements

### DIFF
--- a/lib/plugin.ts
+++ b/lib/plugin.ts
@@ -16,7 +16,8 @@ export default postcss.plugin('postcss-nested-props', () => {
 
 const HAS_COLON = /:/;
 const ALL_PSEUDO = pseudoClasses().concat(pseudoElements());
-const HAS_PSEUDO_CLASSES_ELEMENTS = new RegExp(`:(${ALL_PSEUDO.join('|')})`);
+const VENDOR_PSEUDO_ELEMENTS = '-(\\w|-)+';
+const HAS_PSEUDO_CLASSES_ELEMENTS = new RegExp(`:(${ALL_PSEUDO.join('|')}|${VENDOR_PSEUDO_ELEMENTS})`);
 
 function unwrapRule(namespace: string[], rule: postcss.Rule) {
 	if (!HAS_COLON.test(rule.selector)) {

--- a/test/plugin.ts
+++ b/test/plugin.ts
@@ -65,6 +65,21 @@ describe('postcss-nested-props plugin', () => {
 		});
 	});
 
+	describe('vendor pseudo elements', () => {
+		[
+			'-ms-clear',
+			'-webkit-progress-bar',
+			'-moz-focus-outer'
+		].forEach(vendorPseudoElement => {
+			it(`preserves the ::${vendorPseudoElement} pseudo-element`, () => {
+				check(
+					`a{b::${vendorPseudoElement}{c:d}}`,
+					`a{b::${vendorPseudoElement}{c:d}}`
+				);
+			});
+		});
+	});
+
 });
 
 function check(input: string, output: string) {


### PR DESCRIPTION
Fix for: #3 
This adds a `VENDOR_PSEUDO_ELEMENTS` regex that is appended to `HAS_PSEUDO_CLASSES_ELEMENTS ` 