### PR TITLE
removed lib subdirectory from package.json ref

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "postcss-nested-props",
   "version": "1.1.6",
   "description": "PostCSS plugin to unwrap nested properties.",
-  "main": "dist/lib/plugin.js",
-  "types": "dist/lib/plugin.d.ts",
+  "main": "dist/plugin.js",
+  "types": "dist/plugin.d.ts",
   "scripts": {
     "clean": "rimraf coverage dist *.log",
     "codecov": "codecov -f coverage/lcov.info",


### PR DESCRIPTION
Hi,
I encountered an issue where my runtime requires weren't finding the plugin.js file.

Node was looking to postcss-nested-props/dist/lib/plugin.js as per the package.json, but the actual installed location was postcss-nested-props/dist/plugin.js.

I attempted various other machine-specific fixes:

reinitialized the containing docker container
removing and reinstalling my node_modules in the application
Neither of these resolved the issue.

I am unsure why there hasn't been any other noise on this, and I am additionally confused as my configuration was working not three days ago without the below modification.

This modification resolves this issue by pointing the main and types parameters to the appropriate issue. After this modification, node require can successfully find the plugin.js file.

Thank you for this project. Please let me know if I am errant in anything including the premise of this PR.